### PR TITLE
Export Result in sdk

### DIFF
--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -1453,7 +1453,7 @@ export const deployToJson = (deploy: Deploy) => {
  * Convert a JSON representation of a deploy to a `Deploy` object
  *
  * @param json A JSON representation of a `Deploy`
- * @returns A `Deploy` object from the JSON representation of a deploy
+ * @returns A `Result` that collapses to a `Deploy` or an error string
  */
 export const deployFromJson = (json: any): Result<Deploy, Error> => {
   if (json.deploy === undefined) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,9 @@
+import { Result } from 'ts-results';
 import * as Contracts from './Contracts';
 import * as DeployUtil from './DeployUtil';
 import * as Keys from './Keys';
 import * as Serialization from './Serialization';
 import * as Signer from './Signer';
-import { Result } from 'ts-results';
 export * from './CLValue';
 export * from './StoredValue';
 export * from './RuntimeArgs';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ import * as DeployUtil from './DeployUtil';
 import * as Keys from './Keys';
 import * as Serialization from './Serialization';
 import * as Signer from './Signer';
+import { Result } from 'ts-results';
 export * from './CLValue';
 export * from './StoredValue';
 export * from './RuntimeArgs';
@@ -10,4 +11,4 @@ export * from './CasperClient';
 export * from './SignedMessage';
 export * from './Conversions';
 
-export { Contracts, Keys, Serialization, DeployUtil, Signer };
+export { Contracts, Keys, Serialization, DeployUtil, Signer, Result };


### PR DESCRIPTION
Hi, those lines in DeployUtil

```
export declare const deployFromJson: (json: any) => Result<Deploy, Error>;

export declare const validateDeploy: (deploy: Deploy) => Result<Deploy, string>;
```

return `Result` as type

and this type is not exported so in my app if I need to do

`const signedDeploy: Result<DeployUtil.Deploy, Error> = DeployUtil.deployFromJson(signedDeployToJson);`

then I need to import in my app

`"ts-results": "npm:@casperlabs/ts-results@^3.3.4",`

which is not ideal